### PR TITLE
Update intern package.json posinstall hook

### DIFF
--- a/examples/intern/package.json
+++ b/examples/intern/package.json
@@ -11,8 +11,8 @@
   "homepage": "http://theintern.io/",
   "devDependencies": {
     "intern": "^3.3.2"
-  }, 
+  },
   "scripts": {
-    "postinstall": "cd tests/unit && npm install && cd ../../ && ./node_modules/.bin/intern-client config=tests/intern"
+    "postinstall": "intern-client config=tests/intern"
   }
 }


### PR DESCRIPTION
When executing a locally installed package/module, NPM knows to look for that module locally in `node_modules/.bin/` path without having to explicitly `cd` into that directory and without even having to reference the executable with a relative path (e.g. `node_modules/.bin/intern-client`).